### PR TITLE
Update clusterresourceoverride component mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -537,11 +537,11 @@ bug_mapping:
     ose-cluster-update-keys-container:
       issue_component: Release
     ose-clusterresourceoverride-container:
-      issue_component: Node / Cluster Resource Override Admission Operator
+      issue_component: Cluster Resource Override Admission Operator
     ose-clusterresourceoverride-operator-container:
-      issue_component: Node / Cluster Resource Override Admission Operator
+      issue_component: Cluster Resource Override Admission Operator
     ose-clusterresourceoverride-operator-metadata-container:
-      issue_component: Node / Cluster Resource Override Admission Operator
+      issue_component: Cluster Resource Override Admission Operator
     ose-compliance-openscap-container:
       issue_component: Compliance Operator
     ose-compliance-operator-container:


### PR DESCRIPTION
Cluster Resource Override Admission Operator component listing has changed and has dropped the prefix "Node /".